### PR TITLE
Fix search command hangs and times out.

### DIFF
--- a/internal/commands/search.go
+++ b/internal/commands/search.go
@@ -35,6 +35,8 @@ func (c *searchConfig) run(query string) error {
 	}
 
 	e, err := search.Load()
+	defer e.Close()
+	
 	if err != nil {
 		return fmt.Errorf("load engine: %w", err)
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -19,7 +19,6 @@ func TestMainCLI(t *testing.T) {
 	defer gexec.CleanupBuildArtifacts()
 
 	t.Run("we can search registries", func(t *testing.T) {
-		t.Skip("the search command seems to hang.")
 		command := exec.Command(pathToMainCLI, "search", "k8s", "-r", "./metadata/registries.yml")
 		session, err := gexec.Start(command, os.Stdout, os.Stdout)
 		session.Wait()


### PR DESCRIPTION
Fixes #14 

The order of index construction calls was off, leading to a lock on the index before it could be constructed.
