### PR TITLE
Add a release process for a v0.0.1 version of the CLI

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,29 @@
+name: goreleaser
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      -
+        name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.15
+      -
+        name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,29 @@
+# This is an example goreleaser.yaml file with some sane defaults.
+# Make sure to check the documentation at http://goreleaser.com
+before:
+  hooks:
+    - go mod download
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+archives:
+  - replacements:
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+      386: i386
+      amd64: x86_64
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ .Tag }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'

--- a/README.md
+++ b/README.md
@@ -1,2 +1,44 @@
-# policy-hub-cli
-CLI for searching Rego policies
+# PolicyHub CLI
+
+This is the home of the PolicyHub CLI, a CLI tool that makes Rego policies searchable.
+
+## Goals
+
+Policies are everywhere. Compliance policies, security policies, policies that define organisational best practices. The Open Policy Agent project provided a single policy language, Rego, that can be used to automate policy enforcement. However currently there is no existing mechanism that allows you to search for specific Rego policies.
+
+For example you might be looking for a set of policies that validate Kubernetes security best practices as a starting point for your organisations Kubernetes policies. Or you might be looking for a set of Microservice Authorization policies. Right now you have to hope that your google search points you in the right direction.
+
+The PolicyHub CLI aims to make policies searchable. We provide a standard format for policy creators to share their policies. Users of the CLI can search our registry for specific tags or descriptions, hopefully finding the policy they where looking for.
+
+## Searching policies
+
+To search our registry, you can use the `search` command:
+
+```bash
+> policy-hub search
+
++---------------------------+---------------------------------+--------------------------------+
+|           NAME            |           MAINTAINERS           |             LABELS             |
++---------------------------+---------------------------------+--------------------------------+
+| deprek8ion                | https://github.com/swade1987    | k8s, kubernetes, gatekeeper    |
+| contrib.k8s_node_selector | https://github.com/tsandall     | kubernetes, k8s, node_selector |
+| redhat-cop.rego-policies  | https://github.com/garethahealy | k8s, kubernetes, gatekeeper    |
+| konstraint                | https://github.com/garethahealy | k8s, kubernetes, gatekeeper    |
++---------------------------+---------------------------------+--------------------------------+
+```
+
+## Downloading policies
+
+To download a policy, use the `pull` command:
+
+```bash
+> policy-hub pull konstraint
+```
+
+## Contributing
+
+Join us make policies more searchable!
+
+- We accept contributions to our registry.
+- Use [GitHub Issues](https://github.com/policy-hub/policy-hub-cli/issues) to file bugs or propose new features.
+- Create a [Pull Request](https://github.com/policy-hub/policy-hub-cli/pulls) and contribute to the project.


### PR DESCRIPTION
Add goreleaser to release binaries on git tag pushes.
Update the README in preparation of a release.