### PR TITLE
Add --policy flag to pull command

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ To download a policy, use the `pull` command:
 > policy-hub pull konstraint
 ```
 
+which will download the `konstraint` policies into a folder called `konstraint`. To overwrite the location where the policies will be downloaded too, you can specify the `--policy` flag, e.g.
+
+```bash
+> policy-hub pull konstraint --policy policy
+```
+
 ## Make your policies discoverable
 
 Do you have policies that the community could benefit from too?

--- a/internal/commands/pull.go
+++ b/internal/commands/pull.go
@@ -22,12 +22,13 @@ func newPullCommand() *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&c.Repository, "repository", "r", helpers.DefaultMetaDataFile(), "Location of the repository to search.")
-
+	cmd.Flags().StringVarP(&c.PolicyDir, "policy", "p", "", "Folder where the policies will be downloaded too")
 	return cmd
 }
 
 type pullConfig struct {
 	Repository string
+	PolicyDir string
 }
 
 func (c *pullConfig) run(name string) error {
@@ -47,7 +48,12 @@ func (c *pullConfig) run(name string) error {
 		return fmt.Errorf("could not find a name match in given repository")
 	}
 
-	err = downloader.Download(context.Background(), name, []string{urlPath})
+	policyDir := name
+	if c.PolicyDir != "" {
+		policyDir = c.PolicyDir
+	}
+	
+	err = downloader.Download(context.Background(), policyDir, []string{urlPath})
 	return nil
 }
 


### PR DESCRIPTION
Extend the pull command with a policy flag to specify the download location of the policies