### PR TITLE
feat: add rules from Fugue's Regula repository

### DIFF
--- a/metadata/registries.yml
+++ b/metadata/registries.yml
@@ -235,3 +235,19 @@
     - kubernetes
     - gatekeeper
 
+- path: https://github.com/fugue/regula/rego/rules
+  description: |
+    "Regula checks infrastructure as code templates (Terraform, CloudFormation, k8s manifests) for AWS, Azure, Google Cloud, and Kubernetes security and compliance using Open Policy Agent/Rego"
+  maintainers:
+    - https://github.com/fugue
+  version: master
+  homepage: https://github.com/fugue/regula
+  name: regula
+  labels:
+    - k8s
+    - kubernetes
+    - aws
+    - cloudformation
+    - terraform
+    - azure
+    - arm


### PR DESCRIPTION
## Summary

Love the concept of this repo! There's so many disparate resources and rules, so one place to find all of them would be great!

I'm not sure if this is still maintained, but I can contribute a bunch more of my bookmarks to help with #2 

## Description

- [Regula](https://github.com/fugue/regula) has various CIS compliance checks

- [Fugue](https://github.com/fugue) is a DevSecOps company that uses OPA/Rego for policies
  - They also maintain useful tools like [Fregot](https://github.com/fugue/fregot), a Rego REPL, debugger, etc
  
## Misc

If this gets merged before #26 is fixed, I give my permission for this to be licensed under an open-source license as discussed there.