### PR TITLE
feat: add Instrumenta's Policies repo

### DIFF
--- a/metadata/registries.yml
+++ b/metadata/registries.yml
@@ -235,3 +235,16 @@
     - kubernetes
     - gatekeeper
 
+- path: https://github.com/instrumenta/policies/kubernetes
+  description: |
+    "A set of shared policies for use with Conftest and other Open Policy Agent tools"
+  maintainers:
+    - https://github.com/garethr
+    - https://github.com/jpreese
+  version: master
+  homepage: https://github.com/instrumenta/policies
+  name: instrumenta.policies
+  labels:
+    - k8s
+    - kubernetes
+    - gatekeeper


### PR DESCRIPTION
## Summary

Love the concept of this repo! There's so many disparate resources and rules, so one place to find all of them would be great!

I'm not sure if this is still maintained, but I can contribute a bunch more of my bookmarks to help with #2.
I have probably a few handfuls in addition to this and #27 , but wanted to make sure this was still being maintained first 😅 
Could probably also contribute to #4 and maybe others as well (like a searchable website?). Happy to help maintain!

## Description

feat: add Instrumenta's Policies repo
- meant for policies to be shared across different OPA tools such as Gatekeeper and Conftest, as they have differing data structures and keywords
    
## Misc

If this gets merged before #26 is fixed, I give my permission for this to be licensed under an open-source license as discussed there.